### PR TITLE
Update Docker Guidelines

### DIFF
--- a/development.mediawiki
+++ b/development.mediawiki
@@ -3,8 +3,8 @@
 == SCM Tool ==
 
 * The SCM Tool MUST be [https://github.com Github.com]. Accompanying tools or plugins that integrate well with Github (ex. Gerrit) MAY be used. 
-* Github MUST be used during the <b>whole development lifecycle</b>.  
-* The name of the Github Repository MAY be <i>'fiware' + '-' + "Code Name of your GE"</i>. Example: <code>fiware-orion</code>. Nonetheless,the repository's README.md file <b>MUST</b> include: 
+* Github MUST be used during the '''whole development lifecycle'''.  
+* The name of the Github Repository MAY be <i>'fiware' + '-' + "Code Name of your GE"</i>. Example: <code>fiware-orion</code>. Nonetheless,the repository's README.md file '''MUST''' include: 
 ** the following sentence: <i>'This project is part of FIWARE'</i>. 
 ** a hyperlink to fiware.org. 
 ** a hyperlink to catalogue-server.fiware.org (to the section corresponding to the particular GE). (if the GE has already an entry in the catalogue).
@@ -18,18 +18,18 @@ Apart from the minimal, mandatory lifecycle described by the [[GE_Requirements.m
 
 The development lifecycle of a GE SHOULD be as follows: 
 
-1. When developing a new feature / bug try to <b>divide the work</b> into smaller parts.
+1. When developing a new feature / bug try to '''divide the work''' into smaller parts.
 For instance, dividing by front-end and back-end implementation. There can be other criteria that might depend on each feature / bug.
 The aim of this division is to simplify the review process. Big commits are usually hard to review, hard to change later and prone to conflicts.  
 
-2. Once you have divided the work in parts, the implementation of each part should be done in a <b>different branch</b>
+2. Once you have divided the work in parts, the implementation of each part should be done in a '''different branch'''
 that you will use later to <i>Pull Request</i> to the GE Repository. One recommended practice is that you <i>fork</i> the original repository to your GH account
 and develop the feature in your own branch (which will belong to your own repository).
 Later, you will make a Pull Request from that branch to the GE repository. See [http://nvie.com/posts/a-successful-git-branching-model/].  
 
-3. The Pull Request should include not only the feature's source code but <b>unit or integration tests</b> together with relevant documentation. 
+3. The Pull Request should include not only the feature's source code but '''unit or integration tests''' together with relevant documentation. 
 
-4. At the time of landing (merging), a Pull Request should include <b>only one commit</b>.
+4. At the time of landing (merging), a Pull Request should include '''only one commit'''.
 While developing you may have more than one commit but ultimately <i>only one commit should remain</i>.
 For doing so, use the [https://blog.github.com/2016-04-01-squash-your-commits/ git squash] functionality.
 Nonetheless, there can be situations for which a Pull Request might be better explained with more than one commit.
@@ -40,16 +40,16 @@ Nonetheless, every commit message must be descriptive of what feature or bug the
 <code>ISSUE 345. POST Operation /entities. Part II DB Persistence. </code> <br>
 <code>ISSUE 345. POST Operation /entities. Part III Rendering Responses. </code> 
 
-5. Once a Pull Request is done, a <b>code review</b> will be performed. Find a competent reviewer that can perform a code review.
+5. Once a Pull Request is done, a '''code review''' will be performed. Find a competent reviewer that can perform a code review.
 There can be more than one reviewer but one of them should be a main developer or technical owner/architect of the project.
 Typically the reviewer will test the feature, review the code (style, robustness, structure, performance) and suggest some changes.
 The code review must be made using the code review facilities provided by Github. 
 
 6. Try to address all the comments suggested by reviewers. If a comment is not going to be addressed a rationale should be provided.
 
-7. Wait for a final <b>positive review</b>. This may imply <i>one or more iterations</i> over steps 5 and 6.
+7. Wait for a final '''positive review'''. This may imply <i>one or more iterations</i> over steps 5 and 6.
 
-8. Land (merge) the new code. But before landing <b>ensure that all tests are passing</b>.
+8. Land (merge) the new code. But before landing '''ensure that all tests are passing'''.
 Under certain conditions your Pull Request could not be directly landed (merged). In that case you would need to rebase your branch with the master branch,
 resolve all conflicts, push them and finally merge the new code in the master branch.
 
@@ -58,52 +58,52 @@ That's the advantage of landing only one commit. Backing out code is as easy as 
 
 == Continuous Integration ==
 
-GE projects developed as open source SHOULD have a <b>public continuous integration system</b>. 
+GE projects developed as open source SHOULD have a '''public continuous integration system'''. 
 
-The continuous integration system SHOULD be running <b>every time a new Pull Request</b> (PR) is done.
+The continuous integration system SHOULD be running '''every time a new Pull Request''' (PR) is done.
 As a result the PR owner can know in advance if her code is breaking something. 
 
 Before landing new code the continuous integration system MAY be run in a temporary branch that merge the Pull Request and the destination branch.
-Nonetheless, in the event of continous integration <b>errors</b> the (offending) code MUST be <b>backed out</b> or a fix should be provided urgently. Use git revert for the former. 
+Nonetheless, in the event of continous integration '''errors''' the (offending) code MUST be '''backed out''' or a fix should be provided urgently. Use git revert for the former. 
 
-[https://travis-ci.org/ Travis-Ci] MAY be your <b>continuous integration system</b> as it is super-easy to integrate it with Github.
+[https://travis-ci.org/ Travis-Ci] MAY be your '''continuous integration system''' as it is super-easy to integrate it with Github.
 Jenkins is another popular tool which has the advantage of being able to run on different OS.
 
 Unit tests coverage MAY be provided using open source tools like [https://coveralls.io/ coveralls]. See an example in [https://github.com/Wirecloud/wirecloud https://github.com/Wirecloud/wirecloud]
 
-You MUST include <b>Travis badges</b> (or other badges) in your README.md file. Travis badges can be used to report the current status of your build, (it should be green!).
+You MUST include '''Travis badges''' (or other badges) in your README.md file. Travis badges can be used to report the current status of your build, (it should be green!).
 
 == Tracking ==
 
-A Tracking system MUST be used in order to <b>manage the development work</b>. Such tracking system MUST include at least all the bugs/known issues of your component. 
+A Tracking system MUST be used in order to '''manage the development work'''. Such tracking system MUST include at least all the bugs/known issues of your component. 
 
-The Tracking system SHOULD be <b>public</b>. You MAY use the [https://jira.fiware.org FIWARE Jira] as a <b>public tracking tool</b>.
+The Tracking system SHOULD be '''public'''. You MAY use the [https://jira.fiware.org FIWARE Jira] as a '''public tracking tool'''.
 
-When a commit is actually solving a bug/issue there MUST be a <b>cross-reference</b> between the commit message and the corresponding bug/issue in the Tracking System.  
+When a commit is actually solving a bug/issue there MUST be a '''cross-reference''' between the commit message and the corresponding bug/issue in the Tracking System.  
 
-When users report a new <b>bug</b>, it SHOULD be given an <b>estimation</b> of when the bug will be solved.
+When users report a new '''bug''', it SHOULD be given an '''estimation''' of when the bug will be solved.
 If the bug is consider minor or a very edge case and it will not be resolved,
-it SHOULD be marked as 'WontFix' and closed. This decision MUST be <b>communicated</b> to the reporter together with a suggested workaround. 
+it SHOULD be marked as 'WontFix' and closed. This decision MUST be '''communicated''' to the reporter together with a suggested workaround. 
 
-The <b>roadmap</b> of your component SHOULD be <b>public</b>. Please check the [[GE_Requirements.mediawiki#Roadmap|General Roadmap Requirements]]
+The '''roadmap''' of your component SHOULD be '''public'''. Please check the [[GE_Requirements.mediawiki#Roadmap|General Roadmap Requirements]]
 
-Be prepared for <b>external contributions</b>. When someone makes a Pull Request be responsive and consider carefully the proposal made.
-If you want to <b>create community</b> around your component you should be open minded.
+Be prepared for '''external contributions'''. When someone makes a Pull Request be responsive and consider carefully the proposal made.
+If you want to '''create community''' around your component you should be open minded.
 On the other hand code authored by external contributors should not break the basic design principles of your component. Be prepared for trade-offs.
 
 == Documentation ==
 
 Apart from meeting the [[GE_Requirements.mediawiki#Documentation_Requirements|General Documentation Requirements]] the following guidelines apply. 
 
-To avoid documentation inconsistencies, <b>development related</b> documents MUST be handled in the same way than Source Code, this implies:
+To avoid documentation inconsistencies, '''development related''' documents MUST be handled in the same way than Source Code, this implies:
 
-* <b>Developers oriented</b> documentation MUST be included as part of the Github content. 
-* <b>MarkDown</b> (.md) is the recommended format for document files. Restructured Text (reST) might be used as well. 
+* '''Developers oriented''' documentation MUST be included as part of the Github content. 
+* '''MarkDown''' (.md) is the recommended format for document files. Restructured Text (reST) might be used as well. 
 * Additional developer oriented documentation (advanced topics) MUST be present in a '/doc' folder at the root of your repository (or in an specific documentation repository associated to the GE). It is noteworthy that <i>you MUST use markdown format if you want to benefit from automatic documentation generation systems (readthedocs)</i>.
-* Code and documentation MUST be synced. To this aim, every <b>Pull Request</b> with any impact in existing documentation SHOULD include any related <b>documentation changes</b>.
-* <b>Inconsistencies</b> or lacks of documentation SHOULD be detected in Code Reviews and QA phases, opening <b>bugs</b> when necessary.
+* Code and documentation MUST be synced. To this aim, every '''Pull Request''' with any impact in existing documentation SHOULD include any related '''documentation changes'''.
+* '''Inconsistencies''' or lacks of documentation SHOULD be detected in Code Reviews and QA phases, opening '''bugs''' when necessary.
 
-* A <b>README.md</b> MUST be always present in the root folder of any repository associated to the GE. The purpose of such a document associated to a GE is to document:
+* A '''README.md''' MUST be always present in the root folder of any repository associated to the GE. The purpose of such a document associated to a GE is to document:
 ** GE overall description.
 ** How to Deploy the GE (basic/default installation procedure)
 ** How to run tests
@@ -112,54 +112,57 @@ To avoid documentation inconsistencies, <b>development related</b> documents MUS
 
 More specifically, the referred README SHOULD include:
 
-* Simple GE/Service <b>Description</b> and purpose - 
-** The first paragraph should be an <b>elevator pitch</b> about the purpose of the repository (Since this is displayed on GitHub on mobile) 
-** Include direct <b> Readthedocs</b> links to the <b>User Guide</b>, <b>Admin Guide</b> in a subsequent introductory paragraph (To allow users to navigate directly between code and documentation )
+* Simple GE/Service '''Description''' and purpose - 
+** The first paragraph should be an '''elevator pitch''' about the purpose of the repository (Since this is displayed on GitHub on mobile) 
+** Include direct ''' Readthedocs''' links to the '''User Guide''', '''Admin Guide''' in a subsequent introductory paragraph (To allow users to navigate directly between code and documentation )
 ** Include information about testbed environments if available
 
-* Then add a <b>Table of Contents</b> to make navigation through the rest of the document easier
+* Then add a '''Table of Contents''' to make navigation through the rest of the document easier
 
-* How to <b>Build & Install</b>
+* How to '''Build & Install'''
 ** Make your simplest full stack deployment as easy as possible
 ** Include System requirement info: SO, CPU/Storage Capacity...
 ** Include installation support for your dependencies
 ** Provide a “Hello World” example using curl (basic acceptance test)
 ** Include troubleshooting information for the whole process
 
-* <b>API Overview</b> of the main data flow
+* '''API Overview''' of the main data flow
 ** It is a tutorial, not a reference. It does not need to be exhaustive, it needs to guide the user
 ** Provide always curl examples for this section
 
-* More <b>API Examples</b>
+* More '''API Examples'''
 ** Just the important bits of your API used in examples
 
-* A link to the <b>API Reference Documentation</b>. [https://github.com/OAI/OpenAPI-Specification Open API] SHOULD be used.
+* A link to the '''API Reference Documentation'''. [https://github.com/OAI/OpenAPI-Specification Open API] SHOULD be used.
 
-* How to <b>run tests</b>
+* How to '''run tests'''
 ** End to End tests (MUST). This will be part of the sanity checks included in the "Installation & Administration Guide", thus a link will be needed. 
 ** Unit tests (SHOULD)
 ** Performance tests (MAY)
 
-* List of links to <b>Advanced topics</b> (/doc folder)
+* List of links to '''Advanced topics''' (/doc folder)
 ** User & Programmers Manual            (MUST)
 ** Installation & Administration Guide (MUST)
 ** Other documents, for instance: HA deployment, detailed architecture, Advanced configuration topics, advanced functionalities, ...
 
 == Configuration ==
 
-GEs SHOULD be configurable through a <b>config file</b>. 
+GEs '''SHOULD''' be configurable through a <code>config</code> file. 
 
-If the GE can be configured through a config file a <b>template/example</b> configuration file MUST be present and fully aligned with every branch. 
+Docker images for GEs '''SHOULD''' be configurable. through <code>ENV</code> variables. Where this is not possible
+or desirable, the README.md '''MUST''' explain how to mount a volume to set the configuration
+
+If the GE can be configured through a config file a '''template/example''' configuration file MUST be present and fully aligned with every branch. 
 
 The config file must be seen as part of the documentation (for integrators and deployers).
-So it is mandatory to <b>document every config param</b>, its available options and operation advices.
+So it is mandatory to '''document every config param''', its available options and operation advices.
 [https://github.com/antirez/redis/blob/unstable/redis.conf Redis configuration] is an illustrative example.
 
 == Software Releases (source code) ==
 
 Apart from meeting the general [[GE_Requirements.mediawiki#Releases|Release Requirements]] the following guidelines apply.  
 
-Each code release SHOULD be properly <b>tagged</b> in your Github repository. 
+Each code release SHOULD be properly '''tagged''' in your Github repository. 
 
 Each component should always show a consistent view in the “Releases” and “Tags” tabs at GitHub.com. Examples:
 
@@ -169,16 +172,16 @@ Each component should always show a consistent view in the “Releases” and �
 
 The release notes SHOULD include links for downloading the source code. 
 
-The <b>release notes</b> associated to each Release SHOULD include the <b>changelog</b> for that release,
-i.e. the list of changes regarding the previous version, including (if possible) links to the <b>GitHub issues</b> related to each change.
+The '''release notes''' associated to each Release SHOULD include the '''changelog''' for that release,
+i.e. the list of changes regarding the previous version, including (if possible) links to the '''GitHub issues''' related to each change.
 
 == Binary Releases ==
 
-GEs <b>MUST</b> provide Docker containers according to [[Docker|Docker Guidelines]]. 
+GEs '''MUST''' provide Docker containers according to [[Docker|Docker Guidelines]]. 
 
 == Additional Repository Content ==
 
-Files describing the <b>Licensing and Contribution Policy</b> MUST be included in the repository.
+Files describing the '''Licensing and Contribution Policy''' MUST be included in the repository.
 Please check the [[GE_Requirements.mediawiki#Licensing_Requirements|General GE Licensing Requirements]]. 
 They MUST be consistent with those reflected in the [http://catalogue-server.fiware.org FIWARE Catalogue].
 
@@ -187,9 +190,9 @@ They MUST be consistent with those reflected in the [http://catalogue-server.fiw
 Apart from meeting the general [[GE_Requirements.mediawiki#Ecosystem_Support_and_Quality_Requirements|Ecosystem Support and Quality Requirements]] the following guidelines
 apply.  
 
-[http://stackoverflow.com Stackoverflow] SHOULD be used for thorough technical questions. Educate your users to <b>tag</b> their questions properly in Stackoverflow. 
+[http://stackoverflow.com Stackoverflow] SHOULD be used for thorough technical questions. Educate your users to '''tag''' their questions properly in Stackoverflow. 
 
-Each FIWARE GE <b>MUST</b> be associated to an Stackoverflow tag. Such tag could be specific for a GE or default to a chapter generic tag, for instance <fiware-iot>. 
+Each FIWARE GE '''MUST''' be associated to an Stackoverflow tag. Such tag could be specific for a GE or default to a chapter generic tag, for instance <fiware-iot>. 
 
 Stackoverflow tags SHOULD be of the form ''fiware-<GE codename>''. Example fiware-orion.
 Creating new tags requires Stackoverflow Karma. You MAY ask someone from the FIWARE community with enough Karma to create tags for your GE.
@@ -202,7 +205,7 @@ it could be used instead of the usual fiware-XXXX as an exception, as long as th
 2) the tag is already widely used in StackOverflow (i.e. more than 30 questions using it).
 Anyway, this is a workaround valid only in the case a tag synonym cannot be created due to reputational constraints.
 
-<b>New releases</b> of your components SHOULD be announced through different channels: FIWARE Blog, dedicated Twitter or similar channels, your own Blog ... 
+'''New releases''' of your components SHOULD be announced through different channels: FIWARE Blog, dedicated Twitter or similar channels, your own Blog ... 
 
-Support <b>responsiveness</b> is a MUST. If a feature is not implemented / not available, an alternative <b>workaround</b> MUST be provided.
+Support '''responsiveness''' is a MUST. If a feature is not implemented / not available, an alternative '''workaround''' MUST be provided.
 Afterwards it can be decided whether it is necessary / worth adding such a new feature to your backlog.

--- a/docker.mediawiki
+++ b/docker.mediawiki
@@ -6,40 +6,58 @@ There are three kinds of guidelines included:
 
 * MUST Guidelines. They are mandatory and your GE project must conform to that.
 
-* SHOULD Guidelines. They are not mandatory but <b>highly recommended</b>. 
+* SHOULD Guidelines. They are not mandatory but '''highly recommended'''. 
 
 * MAY Guidelines. They are nice to have.
 
 == Guidelines == 
 
-* At least one Dockerfile (hereby named as 'reference Dockerfile'), intended to GE users, <b>MUST</b> be provided. The base image (Ubuntu, CentOS, etc.) for such a Dockerfile might depend on each GE. 
+* At least one Dockerfile (hereby named as 'reference Dockerfile'), intended to GE users, '''MUST''' be provided. The base image (Ubuntu, CentOS, etc.) for such a Dockerfile might depend on each GE. 
 
-* Hacker-oriented Dockerfiles (intended to GE developers) <b>MAY</b> be provided as well. 
+* Hacker-oriented Dockerfiles (intended to GE developers) '''MAY''' be provided as well. 
 
-* Each Docker container <b>MUST</b> define the following tags (present at [https://hub.docker.com/ Dockerhub]):
-** 'latest':  It will correspond to the latest stable release of the GE. 
-** 'develop': It will correspond to the latest build (latest code snapshot) of the GE. It might not be stable. 
-** '<release n>': one tag per relevant and active stable release. The name of the tag will correspond to the name assigned to the release in Github. 
+* Each Docker container '''MUST''' define the following tags (present at [https://hub.docker.com/ Dockerhub]):
 
-* The reference Dockerfile <b>MUST</b> be present under the 'docker' folder of the GE repository 
+** <code>latest</code>: It will correspond to the latest build (latest code snapshot) of the GE. It might not be stable. 
+** <code>stable</code>:  It will correspond to the latest stable release of the GE. 
+** <code><release n></code>: one tag per relevant and active stable release. The name of the tag will correspond to the name assigned to the release in Github.
+** <code>FIWARE_<release n></code>: one stable release every six months for all FIWARE components. This indicates GEs which will work together
 
-* Should your GE depend on other components (Databases, etc.) you <b>MUST</b> provide a <b>docker-compose.yml</b> file that will allow to instantiate the GE together with its dependencies. 
+* The reference Dockerfile '''MUST''' be present under the 'docker' folder of the GE repository 
 
-* A <b>README.md</b> <b>MUST</b> be provided under the docker folder. Such a README <b>MUST</b> give instructions about how to work with the corresponding Docker container. Please bear in mind that such a README will also be included as part of the Dockerhub documentation. 
+* Should your GE depend on other components (Databases, etc.) you '''MUST''' provide a <code>docker-compose.yml</code> file that will allow to instantiate the GE together with its dependencies. 
 
-* A GE's Docker <b>MUST</b> be published at least under the 'fiware' account on DockerHub (if possible, please avoid the term 'fiware'
+* A README.md '''MUST''' be provided under the docker folder. Such a README '''MUST''' give instructions about how to work with the corresponding Docker container. Please bear in mind that such a README will also be included as part of the Dockerhub documentation. 
+* The README.md '''MUST''' list all available <code>ENV</code> variables that can be supplied to the Docker Image
+
+* If the Docker file hides sensitive information (e.g. passwords) using Docker Secrets The '''README.md''' '''MUST''' list all available <code>ENV</code> variables which have an equivalent <code>_FILE</code> that can be supplied by secrets.
+
+* It '''MUST''' be possible to supply sensitive information using the Docker Secrets mechanism as well as plain text variables for testing. Sensitive information (e.g. passwords) '''MUST NOT''' be passed in plain text - <code>ENV</code> variables alone. 
+
+* It '''SHOULD''' be possible to configure the GE config entirely through - <code>ENV</code> variables. Where this is not possible, the README.md '''MUST''' explain how to mount a volume to set the configuration
+
+* Where configuration occurs via a `config` file, and the image cannot be driven by <code>ENV</code> variables, a sample `config` file '''MUST''' be supplied and injected as part of the Docker build. Dockerfiles '''MUST NOT''' copy default configuration directly from github.
+
+* A GE's Docker '''MUST''' be published at least under the 'fiware' account on DockerHub (if possible, please avoid the term 'fiware'
 in your repository name, as the username already contains it).<br>
 The GE owner will be responsible for publication and maintenance operations. The publication method will be through the 'Automatic Build Procedure'
 which allows to link a Github repository to a Dockerhub one (and keep them in sync). In order to get access to that account and proceed
-with the publication, please get in touch with the FIWARE team at [mailto:fiware-help@lists.fiware.org]. </br>
+with the publication, please get in touch with the FIWARE team at [mailto:fiware-help@lists.fiware.org].
 
-* Dockerfiles and Dockerhub repositories <b>MUST</b> be linked from the FIWARE Catalogue according to the Guidelines defined by the FIWARE Catalogue [http://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Working_with_the_FIWARE_catalogue#Creating_instances]. 
+* Dockerfiles and Dockerhub repositories '''MUST''' be linked from the FIWARE Catalogue according to the Guidelines defined by the FIWARE Catalogue [http://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Working_with_the_FIWARE_catalogue#Creating_instances]. 
 
-* GE Documentation <b>MUST</b> have Docker references (preferably through a link to the formerly mentioned README file)
+* The Github repository README  '''MUST''' have a Docker reference - this is a link on the mandatory Docker Pulls README badge
 
-* Docker containers <b>MUST</b> be tested before being published to the community. Error in Docker materials of a GE will be considered as critical and <b>MUST</b> be fixed immediately. 
+* The Readthedocs GE Installation Documentation '''MUST''' include references to the Docker Hub image, and how to configure it.
 
-* Dockerfiles <b>SHOULD</b> follow best practices as described [https://docs.docker.com/articles/dockerfile_best-practices/ here]
+* Docker containers '''MUST''' be tested before being published to the community. Error in Docker materials of a GE will be considered as critical and '''MUST''' be fixed immediately. 
+
+* Dockerfiles '''SHOULD''' follow best practices as described [https://docs.docker.com/articles/dockerfile_best-practices/ here]
+
+* Dockerfiles '''SHOULD''' be based on the latest LTS release of the base image - e.g. <code>ubuntu:18.04</code>, <code>node:carbon</code> etc.
+
+* Although default values  '''SHOULD'''  be defined, exposed ports '''MUST NOT''' be fixed, and '''MUST''' be configurable using <code>ENV</code> variables.
+
 
 == Examples == 
 


### PR DESCRIPTION
* Media Wiki formatting added consistently
* Docker images for GEs **SHOULD** be configurable. through `ENV` variables.
* Additional best practices added for Sensitive Information using Docker Secrets
* Clarification as to when a `config` file should be used on its own
* Root README needs a Docker Pulls Badge, Read the docs need a Docker section.

Amended tagging section to reflect current practice - specifically  the `latest` tag is currently being used for bleeding edge images

* `latest`: It will correspond to the latest build (latest code snapshot) of the GE. It might not be stable.
* `stable`:  It will correspond to the latest stable release of the GE.
* `<release n>`: one tag per relevant and active stable release. The name of the tag will correspond to the name assigned to the release in Github.
* `FIWARE_<release n>` one stable release every six months for all FIWARE components. This indicates GEs which will work together