### PR TITLE
Amend proposed Badges ordering

### DIFF
--- a/docs/project_badges.md
+++ b/docs/project_badges.md
@@ -7,20 +7,21 @@ This recommendation describes two kind of guidelines for badges: **MUST** (manda
 
 Github repositories `README.md` **MUST** include the following badges at the very beginning of the document: 
 
-*  ![](https://img.shields.io/badge/FIWARE-IoT_Agents-5dc0cf.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAVCAYAAAC33pUlAAAABHNCSVQICAgIfAhkiAAAA8NJREFUSEuVlUtIFlEUx+eO+j3Uz8wSLLJ3pBiBUljRu1WLCAKXbXpQEUFERSQF0aKVFAUVrSJalNXGgmphFEhQiZEIPQwKLbEUK7VvZrRvbr8zzjfNl4/swplz7rn/8z/33HtmRhn/MWzbXmloHVeG0a+VSmAXorXS+oehVD9+0zDN9mgk8n0sWtYnHo5tT9daH4BsM+THQC8naK02jCZ83/HlKaVSzBey1sm8BP9nnUpdjOfl/Qyzj5ust6cnO5FItJLoJqB6yJ4QuNcjVOohegpihshS4F6S7DTVVlNtFFxzNBa7kcaEwUGcbVnH8xOJD67WG9n1NILuKtOsQG9FngOc+lciic1iQ8uQGhJ1kVAKKXUs60RoQ5km93IfaREvuoFj7PZsy9rGXE9G/NhBsDOJ63Acp1J82eFU7OIVO1OxWGwpSU5hb0GqfMydMHYSdiMVnncNY5Vy3VbwRUEydvEaRxmAOSSqJMlJISTxS9YWTYLcg3B253xsPkc5lXk3XLlwrPLuDPKDqDIutzYaj3eweMkPeCCahO3+fEIF8SfLtg/5oI3Mh0ylKM4YRBaYzuBgPuRnBYD3mmhA1X5Aka8NKl4nNz7BaKTzSgsLCzWbvyo4eK9r15WwLKRAmmCXXDoA1kaG2F4jWFbgkxUnlcrB/xj5iHxFPiBN4JekY4nZ6ccOiQ87hgwhe+TOdogT1nfpgEDTvYAucIwHxBfNyhpGrR+F8x00WD33VCNTOr/Wd+9C51Ben7S0ZJUq3qZJ2OkZz+cL87ZfWuePlwRcHZjeUMxFwTrJZAJfSvyWZc1VgORTY8rBcubetdiOk+CO+jPOcCRTF+oZ0okUIyuQeSNL/lPrulg8flhmJHmE2gBpE9xrJNkwpN4rQIIyujGoELCQz8ggG38iGzjKkXufJ2Klun1iu65bnJub2yut3xbEK3UvsDEInCmvA6YjMeE1bCn8F9JBe1eAnS2JksmkIlEDfi8R46kkEkMWdqOv+AvS9rcp2bvk8OAESvgox7h4aWNMLd32jSMLvuwDAwORSE7Oe3ZRKrFwvYGrPOBJ2nZ20Op/mqKNzgraOTPt6Bnx5citUINIczX/jUw3xGL2+ia8KAvsvp0ePoL5hXkXO5YvQYSFAiqcJX8E/gyX8QUvv8eh9XUq3h7mE9tLJoNKqnhHXmCO+dtJ4ybSkH1jc9XRaHTMz1tATBe2UEkeAdKu/zWIkUbZxD+veLxEQhhUFmbnvOezsJrk+zmqMo6vIL2OXzPvQ8v7dgtpoQnkF/LP8Ruu9zXdJHg4igAAAABJRU5ErkJgggA=)  - **FIWARE Chapter** (Link to  https://www.fiware.org/developers/catalogue/  )
-  Example:  `https://img.shields.io/badge/FIWARE-IoT_Agents-5dc0cf.svg` - the full link includes the logo.
+*  ![](https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/iot-agents.svg)  - **FIWARE Chapter** (Link to  https://www.fiware.org/developers/catalogue/  )
+  Example:  `https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/iot-agents.svg` - the full link includes the logo.
 *  ![ ](https://img.shields.io/github/license/telefonicaid/fiware-orion.svg) -  **License** - (Link to the OSS License under the component is offered)
   Example:  `https://img.shields.io/github/license/telefonicaid/fiware-orion.svg`
-* ![ ](https://img.shields.io/readthedocs/fiware-orion.svg) -  **Documentation** (pointer to the documentation on readthedocs corresponding to the branch)
    Example:  `https://img.shields.io/readthedocs/fiware-orion.svg`
 *  ![ ](https://img.shields.io/docker/pulls/fiware/orion.svg)- **Docker** (pointer to the Docker container at the Docker Hub Repository)
   Example: `https://img.shields.io/docker/pulls/fiware/orion.svg`
 * ![ ](https://img.shields.io/badge/tag-fiware--orion-orange.svg?logo=stackoverflow) -  **Stack Overflow** tag (pointer to the  Stack Overflow support channel)
   Example: `https://img.shields.io/badge/tag-fiware--orion-orange.svg?logo=stackoverflow`
 * ![ ](https://img.shields.io/badge/support-askbot-yellowgreen.svg) -  **Support** (pointer to the support channel, askbot, which can be used to get support if Stack Overflow is not used) 
+* A new line character `<br/>`
+* ![ ](https://img.shields.io/readthedocs/fiware-orion.svg) -  **Documentation** (pointer to the documentation on readthedocs corresponding to the branch)
   Example: `https://img.shields.io/badge/support-askbot-yellowgreen.svg`
-* ![ ](https://img.shields.io/maintenance/yes/2019.svg) - **Maintenance** - to show active support for a repository
-   Example: `https://img.shields.io/maintenance/yes/2019.svg`
+* ![ ](https://img.shields.io/badge/status-Full%20Member-brightgreen.svg?&label=GE%20status&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAVCAYAAAC33pUlAAAABHNCSVQICAgIfAhkiAAAA8NJREFUSEuVlUtIFlEUx+eO+j3Uz8wSLLJ3pBiBUljRu1WLCAKXbXpQEUFERSQF0aKVFAUVrSJalNXGgmphFEhQiZEIPQwKLbEUK7VvZrRvbr8zzjfNl4/swplz7rn/8z/33HtmRhn/MWzbXmloHVeG0a+VSmAXorXS+oehVD9+0zDN9mgk8n0sWtYnHo5tT9daH4BsM+THQC8naK02jCZ83/HlKaVSzBey1sm8BP9nnUpdjOfl/Qyzj5ust6cnO5FItJLoJqB6yJ4QuNcjVOohegpihshS4F6S7DTVVlNtFFxzNBa7kcaEwUGcbVnH8xOJD67WG9n1NILuKtOsQG9FngOc+lciic1iQ8uQGhJ1kVAKKXUs60RoQ5km93IfaREvuoFj7PZsy9rGXE9G/NhBsDOJ63Acp1J82eFU7OIVO1OxWGwpSU5hb0GqfMydMHYSdiMVnncNY5Vy3VbwRUEydvEaRxmAOSSqJMlJISTxS9YWTYLcg3B253xsPkc5lXk3XLlwrPLuDPKDqDIutzYaj3eweMkPeCCahO3+fEIF8SfLtg/5oI3Mh0ylKM4YRBaYzuBgPuRnBYD3mmhA1X5Aka8NKl4nNz7BaKTzSgsLCzWbvyo4eK9r15WwLKRAmmCXXDoA1kaG2F4jWFbgkxUnlcrB/xj5iHxFPiBN4JekY4nZ6ccOiQ87hgwhe+TOdogT1nfpgEDTvYAucIwHxBfNyhpGrR+F8x00WD33VCNTOr/Wd+9C51Ben7S0ZJUq3qZJ2OkZz+cL87ZfWuePlwRcHZjeUMxFwTrJZAJfSvyWZc1VgORTY8rBcubetdiOk+CO+jPOcCRTF+oZ0okUIyuQeSNL/lPrulg8flhmJHmE2gBpE9xrJNkwpN4rQIIyujGoELCQz8ggG38iGzjKkXufJ2Klun1iu65bnJub2yut3xbEK3UvsDEInCmvA6YjMeE1bCn8F9JBe1eAnS2JksmkIlEDfi8R46kkEkMWdqOv+AvS9rcp2bvk8OAESvgox7h4aWNMLd32jSMLvuwDAwORSE7Oe3ZRKrFwvYGrPOBJ2nZ20Op/mqKNzgraOTPt6Bnx5citUINIczX/jUw3xGL2+ia8KAvsvp0ePoL5hXkXO5YvQYSFAiqcJX8E/gyX8QUvv8eh9XUq3h7mE9tLJoNKqnhHXmCO+dtJ4ybSkH1jc9XRaHTMz1tATBe2UEkeAdKu/zWIkUbZxD+veLxEQhhUFmbnvOezsJrk+zmqMo6vIL2OXzPvQ8v7dgtpoQnkF/LP8Ruu9zXdJHg4igAAAABJRU5ErkJgggA=) - **GE Status** - to show active support for a repository
+   Example: `https://nexus.lab.fiware.org/static/badges/statuses/orion.svg`
 
 Github repositories `README.md` **SHOULD** include additional badges to display the commitment of the maintainers to high code standards - the following badges are suggested (others may also be suitable): 
 
@@ -36,13 +37,18 @@ The repository's `README.md` badges, where present, **MUST** appear in the follo
 
 * FIWARE Chapter
 * License
+* Docker
+* Stack Overflow
+* Other Support Channels (if provided)
+* `<br/> - new line character
 * Documentation
 * Build Status
 * Coverage
 * Vulnerabilities 
-* Docker
-* Support
-* Maintenance
+* GE Status
+
+The idea being that the first row of badges is informational, the second row displays the state of the project.
+The second row of badges should ideally all be **GREEN** at all times.
 
 Github repositories **MAY** include, among others, badges for: 
 


### PR DESCRIPTION
Updated to use Nexus Badges

The idea being that the first row of badges is informational, the second row displays the state of the project. The second row of badges should ideally all be **GREEN** at all times.